### PR TITLE
Fixed UTF-8 string length calculation

### DIFF
--- a/src/spi/binary/__init__.py
+++ b/src/spi/binary/__init__.py
@@ -29,6 +29,7 @@ import sys
 from datetime import timedelta
 
 logger = logging.getLogger("spi.binary")
+logger.setLevel(10)
 
 class Ensemble:
     """
@@ -91,6 +92,7 @@ class Element:
 
         # encode CData
         if self.cdata is not None: 
+	    print 'rendering cdata: %s' % self.cdata
             logger.debug('rendering cdata: %s', self.cdata)
             data += self.cdata.tobytes()
         
@@ -665,7 +667,7 @@ class CData:
         # b8-15: element data length (0-253 bytes)
         # b16-31: extended element length (256-65536 bytes)
         # b16-39: extended element length (65537-16777216 bytes)
-        datalength = len(self.value)
+        datalength = len(self.value.encode('utf-8'))
         if datalength <= 253:
             tmp = encode_number(datalength, 8)
             bits += tmp


### PR DESCRIPTION
The length of the CData string (line 670 of the binary encoder) was still being calculated on the non-UTF-8 encoded version, but the string itself encoded using UTF-8.